### PR TITLE
Label and credential options should be optional

### DIFF
--- a/docs/en-US/New-BurpSuiteSite.md
+++ b/docs/en-US/New-BurpSuiteSite.md
@@ -27,7 +27,7 @@ Creates a new site.
 ```powershell
 PS C:\> $scope = [PSCustomObject]@{ IncludedUrls = @("http://example.com"); ExcludedUrls = @() }
 PS C:\> $emailRecipient = [PSCustomObject]@{ Email = "foo@example.com" }
-PS C:\> $applicationLogin = [PSCustomObject]@{ Label = "Admin"; Username = "admin"; Password = "ChangeMe" }
+PS C:\> $applicationLogin = [PSCustomObject]@{ Label = "Admin"; Credential = (New-Object System.Management.Automation.PSCredential ("admin", $(ConvertTo-SecureString "ChangeMe" -AsPlainText -Force))) }
 PS C:\> New-BurpSuiteSite -Name "www.example.com" -ParentId 0 -Scope $scope -ScanConfigurationIds '1232asdf23234f' -EmailRecipients $emailRecipient -ApplicationLogins $applicationLogin
 ```
 
@@ -36,7 +36,7 @@ This example shows how to create a new site.
 ## PARAMETERS
 
 ### -ApplicationLogins
-Specifies one or more application login objects. An application login object is a PSCustomObject containing three properties. The first propertie is Label, this is a string that will be use as display name for the login in the BurpSuite UI. The second property is Username, this specifies the username to use for login in if needed. The last property is Password, this specifies the password to use in conjuction with the Username for authenticating to the site.
+Specifies one or more application login objects. An application login object is a PSCustomObject containing two properties. The first propertie is Label, this is a string that will be use as display name for the login in the BurpSuite UI. The second property is Credential, this is a PSCredential object that will be used for authenticating to the site during scans when authentication is needed.
 
 ```yaml
 Type: PSObject[]

--- a/docs/en-US/Update-BurpSuiteSiteApplicationLogin.md
+++ b/docs/en-US/Update-BurpSuiteSiteApplicationLogin.md
@@ -12,9 +12,21 @@ Updates an site application login.
 
 ## SYNTAX
 
+### Credential (Default)
 ```
-Update-BurpSuiteSiteApplicationLogin [-Id] <String> [-Label] <String> [-Credential] <PSCredential> [-WhatIf]
+Update-BurpSuiteSiteApplicationLogin -Id <String> -Credential <PSCredential> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### All
+```
+Update-BurpSuiteSiteApplicationLogin -Id <String> -Label <String> -Credential <PSCredential> [-WhatIf]
  [-Confirm] [<CommonParameters>]
+```
+
+### Label
+```
+Update-BurpSuiteSiteApplicationLogin -Id <String> -Label <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -48,17 +60,17 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies the credentials for the site application login.
+Specifies the credentials of the site application login.
 
 ```yaml
 Type: PSCredential
-Parameter Sets: (All)
+Parameter Sets: Credential, All
 Aliases:
 
 Required: True
-Position: 2
+Position: Named
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -71,22 +83,22 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 0
+Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
 ### -Label
-{{ Fill Label Description }}
+Specifies the new label of the site application login.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: All, Label
 Aliases:
 
 Required: True
-Position: 1
+Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False

--- a/integration/tests/003_SITEAPI.Tests.ps1
+++ b/integration/tests/003_SITEAPI.Tests.ps1
@@ -293,7 +293,7 @@ Describe 'Site API' -Tag 'CD' {
             $siteName = 'Pester - {0}' -f [Guid]::NewGuid()
 
             $scope = [PSCustomObject]@{ IncludedUrls = @("https://pester.dev/") }
-            $applicationLogin = [PSCustomObject]@{ Label = "Admin"; Username = "admin"; Password = "ChangeMe" }
+            $applicationLogin = [PSCustomObject]@{ Label = "Admin"; Credential = (New-Object System.Management.Automation.PSCredential ("admin", $(ConvertTo-SecureString "ChangeMe" -AsPlainText -Force))) }
             New-BurpSuiteSite -ParentId 0 -Name $siteName -Scope $scope -ScanConfigurationIds 'a469d9d4-20ee-4d99-b727-c8072066f761' -ApplicationLogins $applicationLogin
 
             $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }

--- a/integration/tests/003_SITEAPI.Tests.ps1
+++ b/integration/tests/003_SITEAPI.Tests.ps1
@@ -136,7 +136,7 @@ Describe 'Site API' -Tag 'CD' {
             $siteName = 'Pester - {0}' -f [Guid]::NewGuid()
 
             $scope = [PSCustomObject]@{ IncludedUrls = @("https://pester.dev/") }
-            $applicationLogin = [PSCustomObject]@{ Label = "Admin"; Username = "admin"; Password = "ChangeMe" }
+            $applicationLogin = [PSCustomObject]@{ Label = "Admin"; Credential = (New-Object System.Management.Automation.PSCredential ("admin", $(ConvertTo-SecureString "ChangeMe" -AsPlainText -Force))) }
             New-BurpSuiteSite -ParentId 0 -Name $siteName -Scope $scope -ScanConfigurationIds 'a469d9d4-20ee-4d99-b727-c8072066f761' -ApplicationLogins $applicationLogin
 
             $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
@@ -157,7 +157,7 @@ Describe 'Site API' -Tag 'CD' {
         }
     }
 
-    Context 'Update-BurpSuiteSiteApplicationLogin' {
+    Context 'Update-BurpSuiteSiteScanConfiguration' {
         BeforeEach {
             (Get-BurpSuiteSiteTree).sites | Where-Object { $_.name -like 'Pester - *' } | Remove-BurpSuiteSite -Confirm:$false
         }

--- a/integration/tests/003_SITEAPI.Tests.ps1
+++ b/integration/tests/003_SITEAPI.Tests.ps1
@@ -36,9 +36,8 @@ Describe 'Site API' -Tag 'CD' {
             $emailRecipient = [PSCustomObject]@{ Email = "foo@pester.dev" }
 
             $applicationLogin = [PSCustomObject]@{
-                Label = "Admin"
-                Username = "admin"
-                Password = "ChangeMe"
+                Label      = "admin"
+                Credential = (New-Object System.Management.Automation.PSCredential ("admin", $(ConvertTo-SecureString "ChangeMe" -AsPlainText -Force)))
             }
 
             # Act
@@ -78,12 +77,12 @@ Describe 'Site API' -Tag 'CD' {
             $siteName = 'Pester - {0}' -f [Guid]::NewGuid()
 
             New-BurpSuiteFolder -ParentId 0 -Name $folderName
-            $folder = (Get-BurpSuiteSiteTree).folders | Where-Object {$_.Name -eq $folderName}
+            $folder = (Get-BurpSuiteSiteTree).folders | Where-Object { $_.Name -eq $folderName }
 
             $scope = [PSCustomObject]@{ IncludedUrls = @("https://pester.dev/") }
             New-BurpSuiteSite -ParentId $folder.id -Name $siteName -Scope $scope -ScanConfigurationIds 'a469d9d4-20ee-4d99-b727-c8072066f761'
 
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             # Act
             Move-BurpSuiteSite -ParentId 0 -SiteId $site.Id
@@ -112,13 +111,13 @@ Describe 'Site API' -Tag 'CD' {
             $emailRecipient = [PSCustomObject]@{ Email = "foo@example.com" }
             New-BurpSuiteSite -ParentId 0 -Name $siteName -Scope $scope -ScanConfigurationIds 'a469d9d4-20ee-4d99-b727-c8072066f761' -EmailRecipients $emailRecipient
 
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             # Act
             Update-BurpSuiteSiteEmailRecipient -Id $site.email_recipients[0].id -Email "bar@example.com"
 
             # Assert
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
             $site.email_recipients[0].email | Should -Be "bar@example.com"
         }
 
@@ -140,7 +139,7 @@ Describe 'Site API' -Tag 'CD' {
             $applicationLogin = [PSCustomObject]@{ Label = "Admin"; Username = "admin"; Password = "ChangeMe" }
             New-BurpSuiteSite -ParentId 0 -Name $siteName -Scope $scope -ScanConfigurationIds 'a469d9d4-20ee-4d99-b727-c8072066f761' -ApplicationLogins $applicationLogin
 
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             $credentials = New-Object System.Management.Automation.PSCredential ("Admin2", $(ConvertTo-SecureString "changeme2" -AsPlainText -Force))
 
@@ -148,7 +147,7 @@ Describe 'Site API' -Tag 'CD' {
             Update-BurpSuiteSiteApplicationLogin -Id $site.application_logins[0].id -Label "Admin2" -Credential $credentials
 
             # Assert
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
             $site.application_logins[0].label | Should -Be "Admin2"
             $site.application_logins[0].username | Should -Be "Admin2"
         }
@@ -167,19 +166,19 @@ Describe 'Site API' -Tag 'CD' {
             # Arrange
             $siteName = 'Pester - {0}' -f [Guid]::NewGuid()
 
-            $scanConfiguration = Get-BurpSuiteScanConfiguration | Where-Object {$_.name -eq "Audit checks - all except JavaScript analysis"}
+            $scanConfiguration = Get-BurpSuiteScanConfiguration | Where-Object { $_.name -eq "Audit checks - all except JavaScript analysis" }
 
             $scope = [PSCustomObject]@{ IncludedUrls = @("https://pester.dev/") }
             New-BurpSuiteSite -ParentId 0 -Name $siteName -Scope $scope -ScanConfigurationIds $scanConfiguration.id
 
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             # Act
-            $newScanConfiguration = Get-BurpSuiteScanConfiguration | Where-Object {$_.name -eq "Audit checks - all except time-based detection methods"}
+            $newScanConfiguration = Get-BurpSuiteScanConfiguration | Where-Object { $_.name -eq "Audit checks - all except time-based detection methods" }
             Update-BurpSuiteSiteScanConfiguration -Id $site.id -ScanConfigurationIds $newScanConfiguration.id
 
             # Assert
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
             $site.scan_configurations[0].id | Should -Be $newScanConfiguration.id
         }
 
@@ -197,19 +196,19 @@ Describe 'Site API' -Tag 'CD' {
             # Arrange
             $siteName = 'Pester - {0}' -f [Guid]::NewGuid()
 
-            $scanConfiguration = Get-BurpSuiteScanConfiguration | Where-Object {$_.name -eq "Audit checks - all except JavaScript analysis"}
+            $scanConfiguration = Get-BurpSuiteScanConfiguration | Where-Object { $_.name -eq "Audit checks - all except JavaScript analysis" }
 
             $scope = [PSCustomObject]@{ IncludedUrls = @("https://pester.dev/") }
             New-BurpSuiteSite -ParentId 0 -Name $siteName -Scope $scope -ScanConfigurationIds $scanConfiguration.id
 
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             # Act
             $scope = [PSCustomObject]@{ IncludedUrls = @("https://pester2.dev/") }
             Update-BurpSuiteSiteScope -SiteId $site.id -IncludedUrls "https://pester2.dev/" -ExcludedUrls "https://pester2.dev/foo"
 
             # Assert
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             $site.scope.included_urls[0] | Should -Be "https://pester2.dev/"
             $site.scope.excluded_urls[0] | Should -Be "https://pester2.dev/foo"
@@ -229,12 +228,12 @@ Describe 'Site API' -Tag 'CD' {
             # Arrange
             $siteName = 'Pester - {0}' -f [Guid]::NewGuid()
 
-            $scanConfiguration = Get-BurpSuiteScanConfiguration | Where-Object {$_.name -eq "Audit checks - all except JavaScript analysis"}
+            $scanConfiguration = Get-BurpSuiteScanConfiguration | Where-Object { $_.name -eq "Audit checks - all except JavaScript analysis" }
 
             $scope = [PSCustomObject]@{ IncludedUrls = @("https://pester.dev/") }
             New-BurpSuiteSite -ParentId 0 -Name $siteName -Scope $scope -ScanConfigurationIds $scanConfiguration.id
 
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             $credentials = New-Object System.Management.Automation.PSCredential ("Admin", $(ConvertTo-SecureString "changeme" -AsPlainText -Force))
 
@@ -242,7 +241,7 @@ Describe 'Site API' -Tag 'CD' {
             New-BurpSuiteSiteApplicationLogin -SiteId $site.id -Label "Admin" -Credential $credentials
 
             # Assert
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             $site.application_logins[0].label | Should -Be "Admin"
             $site.application_logins[0].username | Should -Be "Admin"
@@ -262,19 +261,19 @@ Describe 'Site API' -Tag 'CD' {
             # Arrange
             $siteName = 'Pester - {0}' -f [Guid]::NewGuid()
 
-            $scanConfiguration = Get-BurpSuiteScanConfiguration | Where-Object {$_.name -eq "Audit checks - all except JavaScript analysis"}
+            $scanConfiguration = Get-BurpSuiteScanConfiguration | Where-Object { $_.name -eq "Audit checks - all except JavaScript analysis" }
 
             $scope = [PSCustomObject]@{ IncludedUrls = @("https://pester.dev/") }
             New-BurpSuiteSite -ParentId 0 -Name $siteName -Scope $scope -ScanConfigurationIds $scanConfiguration.id
 
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
 
             # Act
             New-BurpSuiteSiteEmailRecipient -SiteId $site.id -EmailRecipient "foo@example.com"
 
             # Assert
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             $site.email_recipients[0].email | Should -Be "foo@example.com"
         }
@@ -297,13 +296,13 @@ Describe 'Site API' -Tag 'CD' {
             $applicationLogin = [PSCustomObject]@{ Label = "Admin"; Username = "admin"; Password = "ChangeMe" }
             New-BurpSuiteSite -ParentId 0 -Name $siteName -Scope $scope -ScanConfigurationIds 'a469d9d4-20ee-4d99-b727-c8072066f761' -ApplicationLogins $applicationLogin
 
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             # Act
             Remove-BurpSuiteSiteApplicationLogin -Id $site.application_logins[0].id
 
             # Assert
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
             $site.application_logins[0] | Should -BeNullOrEmpty
         }
 
@@ -325,13 +324,13 @@ Describe 'Site API' -Tag 'CD' {
             $emailRecipient = [PSCustomObject]@{ Email = "foo@example.com" }
             New-BurpSuiteSite -ParentId 0 -Name $siteName -Scope $scope -ScanConfigurationIds 'a469d9d4-20ee-4d99-b727-c8072066f761' -EmailRecipients $emailRecipient
 
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             # Act
             Remove-BurpSuiteSiteEmailRecipient -Id $site.email_recipients[0].id
 
             # Assert
-            $site = (Get-BurpSuiteSiteTree).sites | Where-Object {$_.Name -eq $siteName}
+            $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             $site.email_recipients[0] | Should -BeNullOrEmpty
         }

--- a/src/Public/New-BurpSuiteSite.ps1
+++ b/src/Public/New-BurpSuiteSite.ps1
@@ -74,13 +74,12 @@ function New-BurpSuiteSite {
                         $label = _getObjectProperty -InputObject $applicationLogin -PropertyName 'Label'
                         if ($null -eq $label) { throw "Property 'Label' is required when specifying application login objects." }
 
-                        $username = _getObjectProperty -InputObject $applicationLogin -PropertyName 'Username'
-                        if ($null -eq $username) { throw "Property 'Username' is required when specifying application login objects." }
+                        $credential = _getObjectProperty -InputObject $applicationLogin -PropertyName 'Credential'
+                        if ($null -eq $credential) { throw "Property 'Credential' is required when specifying application login objects." }
 
-                        $password = _getObjectProperty -InputObject $applicationLogin -PropertyName 'Password'
-                        if ($null -eq $password) { throw "Property 'Password' is required when specifying application login objects." }
+                        $networkCredential = $credential.GetNetworkCredential()
 
-                        $applicationLoginInput += @{ label = $label; username = $username; password = $password }
+                        $applicationLoginInput += @{ label = $label; username = $networkCredential.UserName; password = $networkCredential.Password }
                     }
 
                     $variables.input.application_logins = $applicationLoginInput

--- a/src/Public/Update-BurpSuiteSiteApplicationLogin.ps1
+++ b/src/Public/Update-BurpSuiteSiteApplicationLogin.ps1
@@ -1,15 +1,17 @@
 function Update-BurpSuiteSiteApplicationLogin {
-    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [CmdletBinding(DefaultParameterSetName = 'Credential', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     Param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [string] $Id,
 
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Label')]
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'All')]
         [ValidateNotNullOrEmpty()]
         [string] $Label,
 
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Credential')]
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'All')]
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
@@ -25,13 +27,18 @@ function Update-BurpSuiteSiteApplicationLogin {
 
         if ($PSCmdlet.ShouldProcess("BurpSuite", $query)) {
             try {
-                $networkCredential = $Credential.GetNetworkCredential()
-
                 $variables = @{ input = @{} }
                 $variables.input.id = $Id
-                $variables.input.label = $Label
-                $variables.input.username = $networkCredential.UserName
-                $variables.input.password = $networkCredential.Password
+
+                if ($PSBoundParameters.ContainsKey('Label')) {
+                    $variables.input.label = $Label
+                }
+
+                if ($PSBoundParameters.ContainsKey('Credential')) {
+                    $networkCredential = $Credential.GetNetworkCredential()
+                    $variables.input.username = $networkCredential.UserName
+                    $variables.input.password = $networkCredential.Password
+                }
 
                 $request = [Request]::new($query, 'UpdateSiteApplicationLogin', $variables)
 

--- a/unit/tests/public/New-BurpSuiteSite.tests.ps1
+++ b/unit/tests/public/New-BurpSuiteSite.tests.ps1
@@ -15,9 +15,8 @@ InModuleScope $env:BHProjectName {
             )
             $applicationLoginInput = @(
                 [PSCustomObject]@{
-                    Label = "Admin"
-                    Username = "admin"
-                    Password = "ChangeMe"
+                    Label      = "Admin"
+                    Credential = (New-Object System.Management.Automation.PSCredential ("admin", $(ConvertTo-SecureString "ChangeMe" -AsPlainText -Force)))
                 }
             )
             $scanConfigurationIds = "1"
@@ -48,8 +47,8 @@ InModuleScope $env:BHProjectName {
                     -and ($Request.Variables.Input.scope.included_urls -join ',') -eq ($scopeInput.IncludedUrls -join ',') `
                     -and ($Request.Variables.Input.scope.excluded_urls -join ',') -eq ($scopeInput.ExcludedUrls -join ',') `
                     -and $Request.Variables.Input.application_logins[0].label -eq $applicationLoginInput[0].label `
-                    -and $Request.Variables.Input.application_logins[0].username -eq $applicationLoginInput[0].username `
-                    -and $Request.Variables.Input.application_logins[0].password -eq $applicationLoginInput[0].password
+                    -and $Request.Variables.Input.application_logins[0].username -eq (($applicationLoginInput[0].Credential).GetNetworkCredential()).username `
+                    -and $Request.Variables.Input.application_logins[0].password -eq (($applicationLoginInput[0].Credential).GetNetworkCredential()).password
             }
         }
     }

--- a/unit/tests/public/Update-BurpSuiteSiteApplicationLogin.tests.ps1
+++ b/unit/tests/public/Update-BurpSuiteSiteApplicationLogin.tests.ps1
@@ -29,5 +29,67 @@ InModuleScope $env:BHProjectName {
                     -and $Request.Variables.Input.password -eq "changeme"
             }
         }
+
+        Context "Label" {
+            It "should update site application login label" {
+                # arrange
+                Mock -CommandName _callAPI -MockWith {
+                    [PSCustomObject]@{
+                        data = [PSCustomObject]@{
+                            update_site_application_login = [PSCustomObject]@{
+                                application_login = [PSCustomObject]@{
+                                    id = 1
+                                }
+                            }
+                        }
+                    }
+                }
+
+                # act
+                Update-BurpSuiteSiteApplicationLogin -Id 42 -Label "admin"
+
+                # assert
+                Should -Invoke _callAPI -ParameterFilter {
+                    $Request.OperationName -eq "UpdateSiteApplicationLogin" `
+                        -and $Request.Query -eq 'mutation UpdateSiteApplicationLogin($input:''UpdateSiteApplicationLoginInput!'') { update_site_application_login(input:''$input'') { application_login { id label username } } }' `
+                        -and $Request.Variables.Input.id -eq 42 `
+                        -and $Request.Variables.Input.label -eq "admin" `
+                        -and $Request.Variables.Input.ContainsKey('username') -eq $false `
+                        -and $Request.Variables.Input.ContainsKey('password') -eq $false
+                }
+            }
+        }
+
+        Context "Credential" {
+            It "should update site application login credential" {
+                # arrange
+                Mock -CommandName _callAPI -MockWith {
+                    [PSCustomObject]@{
+                        data = [PSCustomObject]@{
+                            update_site_application_login = [PSCustomObject]@{
+                                application_login = [PSCustomObject]@{
+                                    id = 1
+                                }
+                            }
+                        }
+                    }
+                }
+
+                $credentials = New-Object System.Management.Automation.PSCredential ("administrator", $(ConvertTo-SecureString "changeme" -AsPlainText -Force))
+
+                # act
+                Update-BurpSuiteSiteApplicationLogin -Id 42 -Credential $credentials
+
+                # assert
+                Should -Invoke _callAPI -ParameterFilter {
+                    $Request.OperationName -eq "UpdateSiteApplicationLogin" `
+                        -and $Request.Query -eq 'mutation UpdateSiteApplicationLogin($input:''UpdateSiteApplicationLoginInput!'') { update_site_application_login(input:''$input'') { application_login { id label username } } }' `
+                        -and $Request.Variables.Input.id -eq 42 `
+                        -and $Request.Variables.Input.ContainsKey('label') -eq $false `
+                        -and $Request.Variables.Input.username -eq "administrator" `
+                        -and $Request.Variables.Input.password -eq "changeme"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Label and credential options should be optional

## Description
Label and credential options should be optional.

## Motivation and Context
When updating BurpSuite application logins, updating the label or the login credentials none of them are required. So to adhere to the API specifications both parameters should not be required neither.

## How Has This Been Tested?
This has been tested by updating/creating new/existing unit tests and integration tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

