### PR TITLE
Set confirm impact for all remove cmdlets

### DIFF
--- a/integration/tests/003_SITEAPI.Tests.ps1
+++ b/integration/tests/003_SITEAPI.Tests.ps1
@@ -299,7 +299,7 @@ Describe 'Site API' -Tag 'CD' {
             $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             # Act
-            Remove-BurpSuiteSiteApplicationLogin -Id $site.application_logins[0].id
+            Remove-BurpSuiteSiteApplicationLogin -Id $site.application_logins[0].id -Confirm:$false
 
             # Assert
             $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
@@ -327,7 +327,7 @@ Describe 'Site API' -Tag 'CD' {
             $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }
 
             # Act
-            Remove-BurpSuiteSiteEmailRecipient -Id $site.email_recipients[0].id
+            Remove-BurpSuiteSiteEmailRecipient -Id $site.email_recipients[0].id -Confirm:$false
 
             # Assert
             $site = (Get-BurpSuiteSiteTree).sites | Where-Object { $_.Name -eq $siteName }

--- a/src/BurpSuite.psd1
+++ b/src/BurpSuite.psd1
@@ -24,13 +24,13 @@
     Author            = 'Juni Inacio'
 
     # Company or vendor of this module
-    CompanyName       = 'Unknown'
+    CompanyName       = 'Playcool'
 
     # Copyright statement for this module
     Copyright         = '(c) Juni Inacio. All rights reserved.'
 
     # Description of the functionality provided by this module
-    Description       = 'PowerShell module for managing your BurpSuite Enterprise server configuration.'
+    Description       = 'BurpSuite is a PowerShell module with commands for managing BurpSuite Enterprise.'
 
     # Minimum version of the PowerShell engine required by this module
     PowerShellVersion = '5.1'
@@ -69,7 +69,50 @@
     # NestedModules = @()
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = '*-*'
+    FunctionsToExport = @(
+        'Connect-BurpSuite',
+        'Disable-BurpSuiteAgent',
+        'Disconnect-BurpSuite',
+        'Enable-BurpSuiteAgent',
+        'Get-BurpSuiteAgent',
+        'Get-BurpSuiteIssue',
+        'Get-BurpSuiteScan',
+        'Get-BurpSuiteScanConfiguration',
+        'Get-BurpSuiteScanReport',
+        'Get-BurpSuiteScheduleItem',
+        'Get-BurpSuiteSiteTree',
+        'Get-BurpSuiteUnauthorizedAgent',
+        'Grant-BurpSuiteAgent',
+        'Invoke-BurpSuiteAPI',
+        'Move-BurpSuiteFolder',
+        'Move-BurpSuiteSite',
+        'New-BurpSuiteFolder',
+        'New-BurpSuiteScanConfiguration',
+        'New-BurpSuiteScheduleItem',
+        'New-BurpSuiteSite',
+        'New-BurpSuiteSiteApplicationLogin',
+        'New-BurpSuiteSiteEmailRecipient',
+        'Remove-BurpSuiteFolder',
+        'Remove-BurpSuiteScan',
+        'Remove-BurpSuiteScanConfiguration',
+        'Remove-BurpSuiteScheduleItem',
+        'Remove-BurpSuiteSite',
+        'Remove-BurpSuiteSiteApplicationLogin',
+        'Remove-BurpSuiteSiteEmailRecipient',
+        'Rename-BurpSuiteAgent',
+        'Rename-BurpSuiteFolder',
+        'Rename-BurpSuiteSite',
+        'Revoke-BurpSuiteAgent',
+        'Set-BurpSuiteAgentMaxConcurrentScan',
+        'Stop-BurpSuiteScan',
+        'Update-BurpSuiteFalsePositive',
+        'Update-BurpSuiteScanConfiguration',
+        'Update-BurpSuiteScheduleItem',
+        'Update-BurpSuiteSiteApplicationLogin',
+        'Update-BurpSuiteSiteEmailRecipient',
+        'Update-BurpSuiteSiteScanConfiguration',
+        'Update-BurpSuiteSiteScope'
+    )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     # CmdletsToExport = '*'
@@ -78,7 +121,9 @@
     # VariablesToExport = '*'
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    # AliasesToExport = '*'
+    AliasesToExport = @(
+        'Login-BurpSuite'
+    )
 
     # DSC resources to export from this module
     # DscResourcesToExport = @()

--- a/src/Public/Remove-BurpSuiteFolder.ps1
+++ b/src/Public/Remove-BurpSuiteFolder.ps1
@@ -1,5 +1,5 @@
 function Remove-BurpSuiteFolder {
-    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]

--- a/src/Public/Remove-BurpSuiteSite.ps1
+++ b/src/Public/Remove-BurpSuiteSite.ps1
@@ -1,5 +1,5 @@
 function Remove-BurpSuiteSite {
-    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]

--- a/src/Public/Remove-BurpSuiteSiteApplicationLogin.ps1
+++ b/src/Public/Remove-BurpSuiteSiteApplicationLogin.ps1
@@ -1,5 +1,5 @@
 function Remove-BurpSuiteSiteApplicationLogin {
-    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]

--- a/src/Public/Remove-BurpSuiteSiteEmailRecipient.ps1
+++ b/src/Public/Remove-BurpSuiteSiteEmailRecipient.ps1
@@ -1,5 +1,5 @@
 function Remove-BurpSuiteSiteEmailRecipient {
-    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]

--- a/unit/tests/public/Remove-BurpSuiteSiteEmailRecipient.tests.ps1
+++ b/unit/tests/public/Remove-BurpSuiteSiteEmailRecipient.tests.ps1
@@ -13,7 +13,7 @@ InModuleScope $env:BHProjectName {
             }
 
             # act
-            Remove-BurpSuiteSiteEmailRecipient -Id 42
+            Remove-BurpSuiteSiteEmailRecipient -Id 42 -Confirm:$false
 
             # assert
             Should -Invoke _callAPI -ParameterFilter {


### PR DESCRIPTION
Set confirm impact for all remove cmdlets.

## Description
Set confirm impact for all remove cmdlets

## Motivation and Context
All Remove-BurpSuite* cmdlets should set confirm impact to high, so that the user can make a conscious decision about removing certain resources inside BurpSuite.

## How Has This Been Tested?
Updated and corrected unit test accordingly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

