### PR TITLE
Added support for custom Uri paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - 2020-07-30
+
+### Added
+
+- Added support for custom Uri paths.
+
 ## [1.1.0] - 2020-07-19
 
 ### Added

--- a/docs/en-US/Connect-BurpSuite.md
+++ b/docs/en-US/Connect-BurpSuite.md
@@ -13,7 +13,8 @@ Connects BurpSuite to BurpSuite Enterprise.
 ## SYNTAX
 
 ```
-Connect-BurpSuite [-Uri] <String> [-APIKey] <String> [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+Connect-BurpSuite [-Uri] <String> [-APIKey] <String> [[-UriPath] <String>] [-PassThru] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,6 +28,13 @@ PS /> Connect-BurpSuite -APIKey 'd0D99S3Strkcdd8oALICjmPtwJuLbFtKX' -Uri "https:
 ```
 
 This example shows how to connect the module with BurpSuite Enterprise.
+
+### EXAMPLE 2
+```
+PS /> Connect-BurpSuite -APIKey 'd0D99S3Strkcdd8oALICjmPtwJuLbFtKX' -Uri "https://burpsuite.example.org" -UriPath "virtualdir/graphql/v1"
+```
+
+This example shows how to connect the module with BurpSuite Enterprise using a custom Uri path, this results into the following url 'https://burpsuite.example.org/virtualdir/graphql/v1' to the GraphQL endpoint.
 
 ## PARAMETERS
 
@@ -85,6 +93,21 @@ Aliases:
 
 Required: True
 Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UriPath
+Specifies the URL path to BurpSuite GraphQL endpoint, default is '/graphql/v1'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/src/BurpSuite.psd1
+++ b/src/BurpSuite.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'BurpSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.0'
+    ModuleVersion     = '1.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Public/Connect-BurpSuite.ps1
+++ b/src/Public/Connect-BurpSuite.ps1
@@ -15,6 +15,11 @@ function Connect-BurpSuite {
 
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
+        [string]
+        $UriPath,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
         [switch]
         $PassThru
     )
@@ -22,6 +27,8 @@ function Connect-BurpSuite {
     begin {
         $uriBuilder = New-Object -TypeName System.UriBuilder -ArgumentList $Uri
         $uriBuilder.Path = '/graphql/v1'
+
+        if ($PSBoundParameters.ContainsKey('UriPath')) { $uriBuilder.Path = $UriPath }
 
         $apiUrl = $uriBuilder.ToString()
     }

--- a/unit/tests/public/Connect-BurpSuite.tests.ps1
+++ b/unit/tests/public/Connect-BurpSuite.tests.ps1
@@ -62,5 +62,21 @@ InModuleScope $env:BHProjectName {
                 Should -Invoke _removeSession
             }
         }
+
+        Context "Uri" {
+            It "should support custom uri" {
+                # arrange
+                Mock -CommandName _createSession
+                Mock -CommandName _callAPI
+
+                # act
+                Connect-BurpSuite -APIKey 'd0D99S3Strkcdd8oALICjmPtwJuLbFtKX' -Uri "https://burpsuite.example.org" -UriPath 'foo/graphql/v1'
+
+                # assert
+                Should -Invoke _createSession -ParameterFilter {
+                    $APIUrl -eq 'https://burpsuite.example.org:443/foo/graphql/v1'
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Added support for custom Uri paths.

## Description
It could be the case that the path to the GraphQL endpoint is other than the default '/graphql/v1' path. This PR will adds support to the Connect-BrupSuite cmdlet to enable specifying a custom Uri path e.g. '/foo/graphql/v1'. 

## Motivation and Context
Better adoption of the module by the community.

## How Has This Been Tested?
This change has been tested using Unit tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

